### PR TITLE
Allow user to choose directory for files

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 # healthyR.data (development version)
-
+1. Fix #72 - Fix bug in directory file paths for `current_hosp_data()`
 # healthyR.data 1.0.3
 
 ## Breaking Changes

--- a/R/dl-cur-hosp-data.R
+++ b/R/dl-cur-hosp-data.R
@@ -37,15 +37,18 @@ NULL
 #' @export
 #' @rdname current_hosp_data
 
-current_hosp_data <- function() {
+current_hosp_data <- function(path = tempdir()) {
 
     # URL for file
     url <- "https://data.cms.gov/provider-data/sites/default/files/archive/Hospitals/current/hospitals_current_data.zip"
 
     # Create a temporary directory to process the zip file
-    tmp_dir <- tempdir()
-    download_location <- file.path(tmp_dir, "download.zip")
-    extract_location <- file.path(tmp_dir, "extract")
+    download_location <- file.path(path, "download.zip")
+    extract_location <- file.path(path, "extract")
+
+    if (!dir.exists(extract_location)) {
+        dir.create(extract_location)
+    }
 
     # Download the zip file to the temporary location
     utils::download.file(
@@ -88,7 +91,9 @@ current_hosp_data <- function() {
 
     list_of_tables <- lapply(csv_names, parse_csv_file)
 
-    unlink(tmp_dir, recursive = TRUE)
+    if (path == tempdir()) {
+        unlink(path, recursive = TRUE)
+    }
 
     # Return the tibbles)
     # Add and attribute and a class type to the object

--- a/R/dl-cur-hosp-data.R
+++ b/R/dl-cur-hosp-data.R
@@ -44,10 +44,9 @@ current_hosp_data <- function(path = tempdir(), ...) {
 
     # Create a temporary directory to process the zip file
     download_location <- file.path(path, "download.zip")
+    extract_location <- file.path(path, "extract")
 
-    if (!dir.exists(extract_location)) {
-        dir.create(extract_location)
-    }
+    dir.create(extract_location, showWarnings = TRUE)
 
     # Download the zip file to the temporary location
     utils::download.file(
@@ -56,7 +55,7 @@ current_hosp_data <- function(path = tempdir(), ...) {
     )
 
     # Unzip the file
-    utils::unzip(download_location, ...)
+    utils::unzip(download_location, exdir = extract_location, ...)
 
     # Read the csv files into a list
     csv_file_list <- list.files(

--- a/R/dl-cur-hosp-data.R
+++ b/R/dl-cur-hosp-data.R
@@ -23,6 +23,11 @@
 #' to access the data later on. It does have a given attributes and a class so
 #' that it can be piped into other functions.
 #'
+#' @param path The location to download and unzip the files. By default this
+#' will go to a temporary directory
+#'
+#' @inheritDotParams utils::unzip -zipfile -exdir
+#'
 #' @examples
 #' \dontrun{
 #'   current_hosp_data()

--- a/R/dl-cur-hosp-data.R
+++ b/R/dl-cur-hosp-data.R
@@ -42,13 +42,13 @@ current_hosp_data <- function(path = tempdir(), ...) {
     # URL for file
     url <- "https://data.cms.gov/provider-data/sites/default/files/archive/Hospitals/current/hospitals_current_data.zip"
 
-    # Create a temporary directory to process the zip file
+    # Set up directory to process the zip file
     download_location <- file.path(path, "download.zip")
     extract_location <- file.path(path, "extract")
 
     dir.create(extract_location, showWarnings = TRUE)
 
-    # Download the zip file to the temporary location
+    # Download the zip file to the specified location
     utils::download.file(
         url = url,
         destfile = download_location
@@ -89,11 +89,12 @@ current_hosp_data <- function(path = tempdir(), ...) {
 
     list_of_tables <- lapply(csv_names, parse_csv_file)
 
+    # unlink temporary directory if used
     if (path == tempdir()) {
         unlink(path, recursive = TRUE)
     }
 
-    # Return the tibbles)
+    # Return the tibbles
     # Add and attribute and a class type to the object
     attr(list_of_tables, ".list_type") <- "current_hosp_data"
     class(list_of_tables) <- c("current_hosp_data", class(list_of_tables))

--- a/R/dl-cur-hosp-data.R
+++ b/R/dl-cur-hosp-data.R
@@ -51,7 +51,7 @@ current_hosp_data <- function(path = tempdir(), ...) {
     download_location <- file.path(path, "download.zip")
     extract_location <- file.path(path, "extract")
 
-    dir.create(extract_location, showWarnings = TRUE)
+    dir.create(extract_location, showWarnings = FALSE)
 
     # Download the zip file to the specified location
     utils::download.file(

--- a/R/dl-cur-hosp-data.R
+++ b/R/dl-cur-hosp-data.R
@@ -37,14 +37,13 @@ NULL
 #' @export
 #' @rdname current_hosp_data
 
-current_hosp_data <- function(path = tempdir()) {
+current_hosp_data <- function(path = tempdir(), ...) {
 
     # URL for file
     url <- "https://data.cms.gov/provider-data/sites/default/files/archive/Hospitals/current/hospitals_current_data.zip"
 
     # Create a temporary directory to process the zip file
     download_location <- file.path(path, "download.zip")
-    extract_location <- file.path(path, "extract")
 
     if (!dir.exists(extract_location)) {
         dir.create(extract_location)
@@ -57,7 +56,7 @@ current_hosp_data <- function(path = tempdir()) {
     )
 
     # Unzip the file
-    utils::unzip(download_location, exdir = extract_location)
+    utils::unzip(download_location, ...)
 
     # Read the csv files into a list
     csv_file_list <- list.files(

--- a/R/dl-cur-hosp-data.R
+++ b/R/dl-cur-hosp-data.R
@@ -23,8 +23,7 @@
 #' to access the data later on. It does have a given attributes and a class so
 #' that it can be piped into other functions.
 #'
-#' @param path The location to download and unzip the files. By default this
-#' will go to a temporary directory
+#' @param path The location to download and unzip the files
 #'
 #' @examples
 #' \dontrun{
@@ -91,11 +90,6 @@ current_hosp_data <- function(path = utils::choose.dir()) {
     }
 
     list_of_tables <- lapply(csv_names, parse_csv_file)
-
-    # unlink temporary directory if used
-    if (path == tempdir()) {
-        unlink(path, recursive = TRUE)
-    }
 
     # Return the tibbles
     # Add and attribute and a class type to the object

--- a/R/dl-cur-hosp-data.R
+++ b/R/dl-cur-hosp-data.R
@@ -26,8 +26,6 @@
 #' @param path The location to download and unzip the files. By default this
 #' will go to a temporary directory
 #'
-#' @inheritDotParams utils::unzip -zipfile -exdir
-#'
 #' @examples
 #' \dontrun{
 #'   current_hosp_data()
@@ -42,7 +40,7 @@ NULL
 #' @export
 #' @rdname current_hosp_data
 
-current_hosp_data <- function(path = tempdir(), ...) {
+current_hosp_data <- function(path = utils::choose.dir()) {
 
     # URL for file
     url <- "https://data.cms.gov/provider-data/sites/default/files/archive/Hospitals/current/hospitals_current_data.zip"
@@ -60,7 +58,7 @@ current_hosp_data <- function(path = tempdir(), ...) {
     )
 
     # Unzip the file
-    utils::unzip(download_location, exdir = extract_location, ...)
+    utils::unzip(download_location, exdir = extract_location)
 
     # Read the csv files into a list
     csv_file_list <- list.files(

--- a/docs/reference/current_hosp_data.html
+++ b/docs/reference/current_hosp_data.html
@@ -57,9 +57,15 @@
 
     <div class="section level2">
     <h2 id="ref-usage">Usage<a class="anchor" aria-label="anchor" href="#ref-usage"></a></h2>
-    <div class="sourceCode"><pre class="sourceCode r"><code><span><span class="fu">current_hosp_data</span><span class="op">(</span><span class="op">)</span></span></code></pre></div>
+    <div class="sourceCode"><pre class="sourceCode r"><code><span class="fu">current_hosp_data</span><span class="op">(</span>path <span class="op">=</span> <span class="fu">utils</span><span class="fu">::</span><span class="fu"><a href="https://rdrr.io/r/utils/choose.dir.html" class="external-link">choose.dir</a></span><span class="op">(</span><span class="op">)</span><span class="op">)</span></code></pre></div>
     </div>
 
+    <div class="section level2">
+    <h2 id="arguments">Arguments<a class="anchor" aria-label="anchor" href="#arguments"></a></h2>
+    <dl><dt>path</dt>
+<dd><p>The location to download and unzip the files</p></dd>
+
+</dl></div>
     <div class="section level2">
     <h2 id="value">Value<a class="anchor" aria-label="anchor" href="#value"></a></h2>
     
@@ -111,10 +117,10 @@ that it can be piped into other functions.</p>
 
     <div class="section level2">
     <h2 id="ref-examples">Examples<a class="anchor" aria-label="anchor" href="#ref-examples"></a></h2>
-    <div class="sourceCode"><pre class="sourceCode r"><code><span class="r-in"><span><span class="kw">if</span> <span class="op">(</span><span class="cn">FALSE</span><span class="op">)</span> <span class="op">{</span></span></span>
-<span class="r-in"><span>  <span class="fu">current_hosp_data</span><span class="op">(</span><span class="op">)</span></span></span>
-<span class="r-in"><span><span class="op">}</span></span></span>
-<span class="r-in"><span></span></span>
+    <div class="sourceCode"><pre class="sourceCode r"><code><span class="r-in"><span class="kw">if</span> <span class="op">(</span><span class="cn">FALSE</span><span class="op">)</span> <span class="op">{</span></span>
+<span class="r-in">  <span class="fu">current_hosp_data</span><span class="op">(</span><span class="op">)</span></span>
+<span class="r-in"><span class="op">}</span></span>
+<span class="r-in"></span>
 </code></pre></div>
     </div>
   </main><aside class="col-md-3"><nav id="toc"><h2>On this page</h2>

--- a/man/current_hosp_data.Rd
+++ b/man/current_hosp_data.Rd
@@ -4,31 +4,10 @@
 \alias{current_hosp_data}
 \title{Download Current Hospital Data Files.}
 \usage{
-current_hosp_data(path = tempdir(), ...)
+current_hosp_data(path = utils::choose.dir())
 }
 \arguments{
-\item{path}{The location to download and unzip the files. By default this
-will go to a temporary directory}
-
-\item{...}{
-  Arguments passed on to \code{\link[utils:unzip]{utils::unzip}}
-  \describe{
-    \item{\code{files}}{A character vector of recorded filepaths to be extracted:
-    the default is to extract all files.}
-    \item{\code{list}}{If \code{TRUE}, list the files and extract none.  The
-    equivalent of \command{unzip -l}.}
-    \item{\code{overwrite}}{If \code{TRUE}, overwrite existing files (the equivalent
-    of \command{unzip -o}), otherwise ignore such files (the equivalent of
-    \command{unzip -n}).}
-    \item{\code{junkpaths}}{If \code{TRUE}, use only the basename of the stored
-    filepath when extracting.  The equivalent of \command{unzip -j}.}
-    \item{\code{unzip}}{The method to be used.  An alternative is to use
-    \code{getOption("unzip")}, which on a Unix-alike may be set to the
-    path to a \command{unzip} program.}
-    \item{\code{setTimes}}{logical.  For the internal method only, should the
-    file times be set based on the times in the zip file?  (NB: this
-    applies to included files, not to directories.)}
-  }}
+\item{path}{The location to download and unzip the files}
 }
 \value{
 Downloads the current hospital data sets.

--- a/man/current_hosp_data.Rd
+++ b/man/current_hosp_data.Rd
@@ -4,7 +4,31 @@
 \alias{current_hosp_data}
 \title{Download Current Hospital Data Files.}
 \usage{
-current_hosp_data()
+current_hosp_data(path = tempdir(), ...)
+}
+\arguments{
+\item{path}{The location to download and unzip the files. By default this
+will go to a temporary directory}
+
+\item{...}{
+  Arguments passed on to \code{\link[utils:unzip]{utils::unzip}}
+  \describe{
+    \item{\code{files}}{A character vector of recorded filepaths to be extracted:
+    the default is to extract all files.}
+    \item{\code{list}}{If \code{TRUE}, list the files and extract none.  The
+    equivalent of \command{unzip -l}.}
+    \item{\code{overwrite}}{If \code{TRUE}, overwrite existing files (the equivalent
+    of \command{unzip -o}), otherwise ignore such files (the equivalent of
+    \command{unzip -n}).}
+    \item{\code{junkpaths}}{If \code{TRUE}, use only the basename of the stored
+    filepath when extracting.  The equivalent of \command{unzip -j}.}
+    \item{\code{unzip}}{The method to be used.  An alternative is to use
+    \code{getOption("unzip")}, which on a Unix-alike may be set to the
+    path to a \command{unzip} program.}
+    \item{\code{setTimes}}{logical.  For the internal method only, should the
+    file times be set based on the times in the zip file?  (NB: this
+    applies to included files, not to directories.)}
+  }}
 }
 \value{
 Downloads the current hospital data sets.


### PR DESCRIPTION
Fixes #72 
This PR allows the user to choose the directory for downloading and unzipping files instead of using a temporary directory. I chose not to pass `...` to `unzip()` as mentioned in the issue as downloading the data0is one of the longer steps. I wouldn't want the user do download + list files then download + unzip.