### PR TITLE
Fix for httr2 1.1.0

### DIFF
--- a/R/utils-valid-url.R
+++ b/R/utils-valid-url.R
@@ -26,11 +26,13 @@ NULL
 #' @rdname is_valid_url
 #' @export
 is_valid_url <- function(url) {
-    parsed_url <- httr2::url_parse(url)
-    # Check if the parsed URL has a scheme and a host
-    if (is.null(parsed_url$scheme) || is.null(parsed_url$hostname)) {
-        return(FALSE)
-    } else {
-        return(TRUE)
-    }
+    tryCatch(
+        {
+            httr2::url_parse(url)
+            !is.null(parsed_url$scheme) && !is.null(parsed_url$hostname)
+        },
+        error = function(cnd) {
+            FALSE
+        }
+    )
 }


### PR DESCRIPTION
httr2 has switched to a more aggressive URL parser which now throws an error. The proposed code should work with both old and new httr2. I am planning to submit httr2 to CRAN on Jan 17, so you'll have ~2 weeks after this date to get this fix to CRAN.